### PR TITLE
fix: allow File.ReadDir with n == 0

### DIFF
--- a/clientFile.go
+++ b/clientFile.go
@@ -119,8 +119,8 @@ func (f *File) Close() error {
 }
 
 func (f *File) ReadDir(n int) ([]fs.DirEntry, error) {
-	if n != 0 {
-		return nil, errors.New("sftpfs: readdir with n != 0 not implemented")
+	if n > 0 {
+		return nil, errors.New("sftpfs: readdir with n > 0 not implemented")
 	}
 
 	return f.c.ReadDir(f.path)


### PR DESCRIPTION
The fs.ReadDirFile documentation specifies that all values of n <= 0 should return all DirEntry values from the directory, so there's no reason to reject negative n values.